### PR TITLE
Fix healthcheck matcher can not capture

### DIFF
--- a/lib/lbspec/capture.rb
+++ b/lib/lbspec/capture.rb
@@ -117,7 +117,7 @@ module Lbspec
     end
 
     def capture_command
-      "sudo ngrep -W byline #{@prove} #{@bpf} | grep -v \"match:\""
+      %Q(sudo ngrep -W byline "#{@prove}" #{@bpf} | grep -v "match:")
     end
   end
 end


### PR DESCRIPTION
Fix healthcheck matcher can not capture
- good:
  `sudo ngrep -W byline "" src host xx.xx.xx.xx | grep -v "match:"`

```
interface: en0 (xx.xx.xx.0/255.255.255.0)
filter: (ip) and ( src host xx.xx.xx.xx )
```
- bad:
  `sudo ngrep -W byline  src host xx.xx.xx.xx | grep -v "match:"`

```
interface: en0 (xx.xx.xx.0/255.255.255.0)
filter: (ip) and ( host xx.xx.xx.xx )
match: src
```
