### PR TITLE
Fix to use local user name when ssh/config does not specify user name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+sudo: false
 language: ruby
 cache: bundler
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.3
+  - 2.1
+  - 2.2

--- a/lib/lbspec/capture.rb
+++ b/lib/lbspec/capture.rb
@@ -58,7 +58,8 @@ module Lbspec
 
     def open_node(node)
       @threads << Thread.new do
-        Net::SSH.start(node, nil, config: true) do |ssh|
+        user = Util.ssh_user(node)
+        Net::SSH.start(node, user, config: true) do |ssh|
           @ssh << ssh
           ssh.open_channel do |channel|
             output = run_check channel

--- a/lib/lbspec/util.rb
+++ b/lib/lbspec/util.rb
@@ -67,7 +67,7 @@ module Lbspec
       # if there is no user for the node in ~/.ssh/config
       # use current user name for login
       user = Net::SSH::Config.for(node)[:user]
-      user ? user : `whoami`.chomp
+      user = user ? user : `whoami`.chomp
       log.debug("ssh #{node} as user:#{user}")
       user
     end


### PR DESCRIPTION
It was seemed to be a refactoring miss on 97327578 and there was not used for capturing.