### PR TITLE
Change ngrep line buffered

### DIFF
--- a/lib/lbspec/capture.rb
+++ b/lib/lbspec/capture.rb
@@ -118,7 +118,7 @@ module Lbspec
     end
 
     def capture_command
-      %Q(sudo ngrep -W byline "#{@prove}" #{@bpf} | grep -v "match:")
+      %Q(sudo ngrep -l -W byline "#{@prove}" #{@bpf} | grep -v "match:")
     end
   end
 end

--- a/lib/lbspec/capture.rb
+++ b/lib/lbspec/capture.rb
@@ -118,7 +118,7 @@ module Lbspec
     end
 
     def capture_command
-      %Q(sudo ngrep -l -W byline "#{@prove}" #{@bpf} | grep -v "match:")
+      %Q(sudo ngrep -l -d any -W byline "#{@prove}" #{@bpf} | grep -v "match:")
     end
   end
 end


### PR DESCRIPTION
## Problem

Ngrep command buffers captured output to STDOUT. So if only a few packets are captured, ngrep does not output anything to STDOUT. Lbspec detects if ssh connected with output of STDOUT. Therefore lbspec waits forever if only a few packets are captured.
## Solution

Change ngrep to line buffered.(print each line)
